### PR TITLE
fix ngRepeat:dupes error

### DIFF
--- a/src/json-tree.js
+++ b/src/json-tree.js
@@ -100,7 +100,7 @@ angular.module('angular-json-tree', ['ajs.RecursiveDirectiveHelper'])
                 '       <span class="leaf-value" ng-if="!isExpandable">{{value}}</span>' +
                 '       <span class="branch-preview" ng-if="isExpandable" ng-show="!isExpanded" ng-click="toggleExpanded()">{{preview}}</span>' +
                 '       <ul class="branch-value" ng-if="isExpandable && shouldRender" ng-show="isExpanded">' +
-                '           <li ng-repeat="(subkey,subval) in value track by ($index+subval)">' +
+                '           <li ng-repeat="(subkey,subval) in value track by ($index+subkey+subval)">' +
                 '               <json-node key="subkey" value="subval"></json-node>' +
                 '           </li>' +
                 '       </ul>',

--- a/src/json-tree.js
+++ b/src/json-tree.js
@@ -100,7 +100,7 @@ angular.module('angular-json-tree', ['ajs.RecursiveDirectiveHelper'])
                 '       <span class="leaf-value" ng-if="!isExpandable">{{value}}</span>' +
                 '       <span class="branch-preview" ng-if="isExpandable" ng-show="!isExpanded" ng-click="toggleExpanded()">{{preview}}</span>' +
                 '       <ul class="branch-value" ng-if="isExpandable && shouldRender" ng-show="isExpanded">' +
-                '           <li ng-repeat="(subkey,subval) in value">' +
+                '           <li ng-repeat="(subkey,subval) in value track by ($index+subval)">' +
                 '               <json-node key="subkey" value="subval"></json-node>' +
                 '           </li>' +
                 '       </ul>',


### PR DESCRIPTION
used $index+subval instead of $index to force the tree to update when a value changes.
